### PR TITLE
Updated gitter link for lobby.

### DIFF
--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -173,7 +173,7 @@
       <i class="github icon"></i>
       Open Issues
     </a>
-    <a class="item" href="https://gitter.im/coding-blocks/boss-2018-lobby" target="_blank" >
+    <a class="item" href="https://gitter.im/coding-blocks/boss-2019-lobby" target="_blank" >
       <i class="gitter icon"></i> Gitter
     </a>
   </div>


### PR DESCRIPTION
Changed the gitter link from 2018 to 2019 lobby.
Close #183.