### PR TITLE
Link changed from Gitter to Discord

### DIFF
--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -183,8 +183,8 @@
       <i class="github icon"></i>
       Open Issues
     </a>
-    <a class="item" href="https://gitter.im/coding-blocks/boss-2019-lobby" target="_blank" >
-      <i class="gitter icon"></i> Gitter
+    <a class="item" href="https://discord.gg/CV4fUna" target="_blank" >
+      <i class="discord icon"></i> Discord
     </a>
   </div>
   {{#if isAuthenticated}}


### PR DESCRIPTION
The link on the navigation menu has been changed from Gitter to the Discord server as discussions from here onwards will take place in discord. Screenshot of the change:
![gitter_to_discordCHANGED](https://user-images.githubusercontent.com/55018280/82114169-b06ca000-9778-11ea-8254-4019ba298bcd.jpg)
