### PR TITLE
Adding CI Script to build, test, cover project 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: node_js
+
+node_js:
+  - 10
+
+services:
+  - postgresql
+
+before_script:
+  - psql -c 'create database boss;' -U postgres
+
+install:
+  - npm install
+  - echo $SECRETS > secrets.json
+
+script:
+  - npm run start
+  - npm run cover
+
+after_success:
+  - echo "DONE"


### PR DESCRIPTION
Fixes #207

Configuration required by admin:
- since many other coding blocks projects use Travis ci, it means coding blocks have set up integration with Travis
- addition of one environment variable in Travis build config, named ***SECRETS*** which stores the contents of secrets-sample.json, working and live secrets.
- database services requested on CI build
- project built 
- coverage checked (bot not integrated, separate task)