### PR TITLE
Prevent 500 on invalid year 

### DIFF
--- a/routes/root.js
+++ b/routes/root.js
@@ -40,12 +40,20 @@ route.get('/logout', (req, res) => {
 })
 
 route.get('/leaderboard/:year?', (req, res) => {
-  const { year } = req.params
-  const options = {
-    page: req.query.page || 1,
-    size: req.query.size || config.PAGINATION_SIZE,
-    year
-  }
+    let { year } = req.params
+    const validYears = [2020, 2019, 2018]
+  
+    if (!validYears.includes(year)) {
+        return res.status(404).render('pages/404');
+    } else {
+      year = parseInt(year)
+    }
+
+    const options = {
+        page: req.query.page || 1,
+        size: req.query.size || config.PAGINATION_SIZE,
+        year
+    }
 
   options.page = parseInt(options.page)
 


### PR DESCRIPTION
Fixes #272

The route throws 500 error when:

- a noninteger year passed into URL
- a year passed for which entries don't exist for boss (for example 2050)

Feature Improvements:
- by default, it would show the latest year leaderboard if an arbitrary year passed