### PR TITLE
fixes #292 - Linked discord instead of gitter

### DIFF
--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -183,8 +183,8 @@
       <i class="github icon"></i>
       Open Issues
     </a>
-    <a class="item" href="https://gitter.im/coding-blocks/boss-2019-lobby" target="_blank" >
-      <i class="gitter icon"></i> Gitter
+    <a class="item" href="https://discord.gg/8PPQMrx" target="_blank" >
+      <i class="gitter icon"></i> Discord
     </a>
   </div>
   {{#if isAuthenticated}}


### PR DESCRIPTION
Fixed #292 : Changed link from gitter to discord