### PR TITLE
Added color to the navbar

### DIFF
--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -137,7 +137,7 @@
 </head>
 <body>
 
-<div class="ui top fixed huge fluid secondary pointing stackable menu red">
+<div class="ui top fixed huge fluid secondary pointing stackable menu red" style="background-color: #fff;">
   <div class="item boss-link-container">
     <a href="/">
       <img height="38" class="boss-link" src="/images/bosslogo.png">


### PR DESCRIPTION
Fix- [217](https://github.com/coding-blocks/boss/issues/217)

Change- Page contents were overlapping with the nav-bar contents due to transparency, i have added color to the nav-bar which will prevent them from overlapping.

<img width="960" alt="2020-05-18 (7)" src="https://user-images.githubusercontent.com/51786499/82237463-48be7c80-9953-11ea-8c90-57a6410e479f.png">
