### PR TITLE
Boss Mobile navbar made more responsive issue#214

### DIFF
--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -127,7 +127,7 @@
             $(".hamburger-container").click(function() {
                 if (!toggle) {
                     $(".menu.fluid").css({
-                        'height': '100%'
+                        'height': 'fit-content'
                     });
                     toggle = 1;
                 } else {


### PR DESCRIPTION
I made the navbar of boss website for mobile more reponsive and here are the ScreenShot of those.
![Annotation 2020-05-24 004352](https://user-images.githubusercontent.com/54815094/82738926-0cc35700-9d59-11ea-97b9-fe2192d16b70.png)
![Annotation 2020-05-24 004251](https://user-images.githubusercontent.com/54815094/82738932-1f3d9080-9d59-11ea-868f-a0e26847a94d.png)

@championswimmer @abhishek97 @hereisnaman please review this 
Fix for issue #214 