### PR TITLE
Discord's Broken link fixed

### DIFF
--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -79,7 +79,7 @@
                 </li>
 
                 <li class="nav-item" href="https://discord.gg/CV4fUna" target="_blank">
-                    <a class="nav-link" href="#"><i class="fab fa-discord"></i> Discord</a>
+                    <a class="nav-link" href="https://discord.gg/CV4fUna"><i class="fab fa-discord"></i> Discord</a>
                 </li>
 
             </ul>


### PR DESCRIPTION
Now the Discord's link works fine, 
Here is the gif of that @hereisnaman can you please review this.
Fix for issue #354 
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/54815094/83072809-0a306c80-a08d-11ea-86d2-9b23b629b440.gif)
