### PR TITLE
Adding space between Login button and name

### DIFF
--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -84,8 +84,8 @@
 
             </ul>
             {{#if isAuthenticated}}
-            <div class="item right">
-                <a target="_blank" href="https://account.codingblocks.com/users/me">Welcome {{user.firstname}} </a>
+            <div class="item right mr-2">
+                <a target="_blank" href="https://account.codingblocks.com/users/me">Welcome {{user.firstname}}</a>
             </div>
             <a href="/logout" class="btn btn-outline-primary btn-sm" type="button">Logout</a>
             {{else}}


### PR DESCRIPTION
Fixes #363
![image](https://user-images.githubusercontent.com/14032427/83138988-443f5400-a109-11ea-8521-08c100123662.png)


previously:
![image](https://user-images.githubusercontent.com/14032427/83139264-b31cad00-a109-11ea-8e51-d857bacab232.png)
