### PR TITLE
PR's are now pointing at PR's link

### DIFF
--- a/views/pages/claims/id.hbs
+++ b/views/pages/claims/id.hbs
@@ -81,7 +81,7 @@
                             <br />
 
                             <span class="text-muted">Pull Request: <small><a
-                                        href="{{claim.issueUrl}}">{{claim.issueUrl}}</a></small></span>
+                                        href="{{claim.pullUrl}}">{{claim.pullUrl}}</a></small></span>
                             <br />
                         </p>
                     </div>

--- a/views/pages/claims/view.hbs
+++ b/views/pages/claims/view.hbs
@@ -67,7 +67,7 @@
                                                 <br />
 
                                                 <span class="text-muted">Pull Request: <small><a
-                                                            href="{{claim.issueUrl}}">{{claim.issueUrl}}</a></small></span>
+                                                            href="{{claim.pullUrl}}">{{claim.pullUrl}}</a></small></span>
                                                 <br />
                                             </p>
                                         </div>


### PR DESCRIPTION
I had fixed the issue #368 with the least changes possible and only in one commit..
![Annotation 2020-05-24 004352](https://user-images.githubusercontent.com/54815094/83178547-47a10280-a13e-11ea-86ec-fa3a9b2ef34d.png)
