### PR TITLE
fixed leaderboard pagination

### DIFF
--- a/routes/root.js
+++ b/routes/root.js
@@ -80,15 +80,15 @@ route.get('/leaderboard/:year?', async (req, res) => {
       })
       for (var i = 1; i <= lastPage; i++) pagination.push({ link: `?page=${i}&size=${options.size}`, index: i })
 
-      let newPagination = pagination.slice(Math.max(0, options.page - 3), Math.min(options.page + 2, pagination.length))
-      if (newPagination[0].index != 1) {
-        newPagination.unshift({ link: '#', index: '. . .' })
-        newPagination.unshift({ link: `?page=${1}&size=${options.size}`, index: 1 })
-      }
-      if (newPagination[newPagination.length - 1].index != lastPage) {
-        newPagination.push({ link: '#', index: '. . .' })
-        newPagination.push({ link: `?page=${lastPage}&size=${options.size}`, index: lastPage })
-      }
+      // let newPagination = pagination.slice(Math.max(0, options.page - 3), Math.min(options.page + 2, pagination.length))
+      // if (newPagination[0].index != 1) {
+      //   newPagination.unshift({ link: '#', index: '. . .' })
+      //   newPagination.unshift({ link: `?page=${1}&size=${options.size}`, index: 1 })
+      // }
+      // if (newPagination[newPagination.length - 1].index != lastPage) {
+      //   newPagination.push({ link: '#', index: '. . .' })
+      //   newPagination.push({ link: `?page=${lastPage}&size=${options.size}`, index: lastPage })
+      // }
 
       res.render('pages/leaderboard', {
         prevPage: options.page - 1,
@@ -97,7 +97,7 @@ route.get('/leaderboard/:year?', async (req, res) => {
         isLastPage: options.page == lastPage,
         size: options.size,
         page: options.page,
-        pagination: newPagination,
+        pagination: pagination,
         userstats: rows,
         loggedInUser,
         showUserAtTop,

--- a/views/pages/leaderboard.hbs
+++ b/views/pages/leaderboard.hbs
@@ -63,7 +63,7 @@
         $(document).ready(function () {
             let initialTrigger = false;
             $('#page-selection').twbsPagination({
-            totalPages: {{pagination.length}}+1,
+            totalPages: {{pagination.length}},
             visiblePages: 5,
             startPage: {{page}},
             next: 'Next',


### PR DESCRIPTION
closes #397 closes #398 
Further, currently when you press Last button it doesn't takes you on last page. This PR fixes that issues too. Click on Last and you will be at 7th page (not 6th as it is doing now).

Summary:

After a debugging session, I found that previously they tried to implement the pagination feature to move directly to the first page and last page (in case we are in the middle of the pagination pages) which isn't working.
[The implementation expected to be made](https://github.com/coding-blocks/boss/issues/309#issuecomment-630881941)

I just commented out the code (which was breaking stuff) out for now because the feature is already not working (as you can check [here](https://boss.codingblocks.com/leaderboard/2020?page=4&size=10) and can be created as a separate new issue like [this](https://github.com/coding-blocks/boss/issues/326). Further, I made minor changes to get the pagination back to working condition.  I personally tested this with 7 pages of pagination with various `size` and empty database, works fine.