### PR TITLE
pagination refactor

### DIFF
--- a/routes/root.js
+++ b/routes/root.js
@@ -82,16 +82,6 @@ route.get('/leaderboard/:year?', async (req, res) => {
       })
       for (var i = 1; i <= lastPage; i++) pagination.push({ link: `?page=${i}&size=${options.size}`, index: i })
 
-      let newPagination = pagination.slice(Math.max(0, options.page - 3), Math.min(options.page + 2, pagination.length))
-      if (newPagination[0].index != 1) {
-        newPagination.unshift({ link: '#', index: '. . .' })
-        newPagination.unshift({ link: `?page=${1}&size=${options.size}`, index: 1 })
-      }
-      if (newPagination[newPagination.length - 1].index != lastPage) {
-        newPagination.push({ link: '#', index: '. . .' })
-        newPagination.push({ link: `?page=${lastPage}&size=${options.size}`, index: lastPage })
-      }
-
       res.render('pages/leaderboard', {
         prevPage: options.page - 1,
         nextPage: options.page + 1,
@@ -99,7 +89,7 @@ route.get('/leaderboard/:year?', async (req, res) => {
         isLastPage: options.page == lastPage,
         size: options.size,
         page: options.page,
-        pagination: newPagination,
+        pagination: pagination,
         userstats: rows,
         loggedInUser,
         showUserAtTop,

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -16,6 +16,7 @@
     <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://esimakin.github.io/twbs-pagination/jQuery%20Pagination%20plugin_files/jquery.twbsPagination.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/simplePagination.js/1.6/jquery.simplePagination.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.17/dist/js/bootstrap-select.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@coding-blocks/bootstrap@4.5.2/dist/js/bootstrap.min.js" integrity="sha384-5kiNX2pRMEoJOeg8N1XzHzWAotDv8A4fZW6cFGvsDgSZmMuECwtOeZ1ta0eO7DBD" crossorigin="anonymous"></script>
 

--- a/views/pages/leaderboard.hbs
+++ b/views/pages/leaderboard.hbs
@@ -52,8 +52,7 @@
         {{!-- pagination starts --}}
         <div class="card-footer">
             <nav aria-label="Page navigation">
-                <ul class="pagination justify-content-center">
-                    <div id="page-selection"></div>
+                <ul id="page-selection" class="pagination justify-content-center">
                 </ul>
             </nav>
         </div>
@@ -62,22 +61,35 @@
     <script>
         $(document).ready(function () {
             let initialTrigger = false;
-            $('#page-selection').twbsPagination({
-            totalPages: {{pagination.length}}+1,
-            visiblePages: 5,
-            startPage: {{page}},
-            next: 'Next',
-            prev: 'Prev',
-            onPageClick: function (event, page) {
-                console.log({{pagination.length}})
-                    console.log(`?page=${page}&size={{size}}`)
-                    if (!initialTrigger) {
-                        initialTrigger = true;
-                    } else {
-                        window.location.href = `?page=${page}&size={{size}}`
-                    }
+            $('#page-selection').pagination({
+                items: {{pagination.length}},
+                itemOnPage: 5,
+                nextText: '<span aria-hidden="true">&raquo;</span>',
+                prevText: '<span aria-hidden="true">&laquo;</span>',
+                currentPage: {{page}},
+                displayedPages: 3,
+                onPageClick: function (page, event) {
+                    configureButtons();
+                    $('.page-item:first').addClass('disabled');
+                    $('.page-item:last').addClass('disabled');
+                    window.location.href = `?page=${page}&size={{size}}`
+                },
+                onInit: function() {
+                    configureButtons();
                 }
             })
+
+            function configureButtons()
+            {
+                $('.pagination li').addClass('page-item');
+                $('.pagination li a').addClass('page-link');
+                $('.current').addClass('page-link');
+                $('.ellipse').addClass('page-link');
+                if({{page}} == 1)
+                    $('.page-item:first').addClass('disabled');
+                if({{page}} == {{pagination.length}} || {{pagination.length}} == 0)
+                    $('.page-item:last').addClass('disabled');
+            }
         });
     </script>
 </div>


### PR DESCRIPTION
closes #397 closes #398 
Fixes
1) #397 
2) #398 
3) Clicking on Last doesn't take you on last page.
4) `...` feature wasn't working even though code was there.

I removed `Last` and `First` button here because first and last page links are always there. Let me know if you want to have Next and Prev text instead of those arrows.

Screenshots:
![Screenshot from 2020-06-05 22-22-33](https://user-images.githubusercontent.com/30543444/83903072-24e49e80-a77b-11ea-83fb-35542e8de748.png)
![Screenshot from 2020-06-05 22-23-03](https://user-images.githubusercontent.com/30543444/83903103-32018d80-a77b-11ea-9bd5-d813fbbf34f5.png)
