### PR TITLE
Added Conflicting Claims count pill on Claims listing

### DIFF
--- a/utils/datautils.js
+++ b/utils/datautils.js
@@ -98,6 +98,26 @@ function getConflictedClaims(claim,issueUrlDetail,pullUrlType) {
   })
 }
 
+function getConflictsCount(claim,issueUrlDetail,pullUrlType) {
+  projectName = '/' + issueUrlDetail.project + '/'
+  issueId = '/' + issueUrlDetail.id
+  pullUrlType = projectName + pullUrlType + '/'
+  return db.Claim.count({
+    where : {
+      [Op.and] : [
+        {
+          [Op.or] : [
+            { issueUrl: { [Op.like]: '%' + projectName + '%' + issueId } },
+            { issueUrl: { [Op.like]: '%' + projectName + '%' + issueId + '/' } }
+          ]
+        },
+        { pullUrl: { [Op.like]: '%' + pullUrlType + '%' } },
+        { id : { [Op.ne] : claim.id } }
+      ]
+    }
+  })
+}
+
 function updateClaim(claimId, { status, reason, bounty }) {
   const claim = {
     action: 'update',
@@ -252,5 +272,6 @@ module.exports = {
   updateClaim,
   getCounts,
   getConflictedClaims,
-  getResourceFromUrl
+  getResourceFromUrl,
+  getConflictsCount
 }

--- a/views/pages/claims/id.hbs
+++ b/views/pages/claims/id.hbs
@@ -153,8 +153,6 @@
                 </div>
             </div>
         {{/each}}
-        {{else}}
-            <h3 style="margin-top: 1em;">No Conflicted claims</h3>
         {{/if}}
     </div>
 </div>

--- a/views/pages/claims/view.hbs
+++ b/views/pages/claims/view.hbs
@@ -59,6 +59,9 @@
                                                 {{#if claim.reason}}
                                                 <small class="text-muted">Reason: {{claim.reason}}</small>
                                                 {{/if}}
+                                                {{#if claim.conflictCount}}
+                                                <span class="badge badge-danger">Conflicts <span class="badge badge-light">{{claim.conflictCount}}</span></span>
+                                                {{/if}}
                                                 <br />
                                                 <small class="text-muted">Project : <a
                                                         href="https://www.github.com/coding-blocks/{{claim.repo}}">{{claim.repo}}</a></small>


### PR DESCRIPTION
Signed-off-by: prathambatra <batrapratham999@gmail.com>
fixes #399 
![Screenshot from 2020-06-06 01-40-09](https://user-images.githubusercontent.com/29707062/83919296-ef9a7980-a797-11ea-99f1-78a20feac36a.png)
![Screenshot from 2020-06-06 01-40-19](https://user-images.githubusercontent.com/29707062/83919310-f4f7c400-a797-11ea-8f05-e70c0e5ea85c.png)
![Screenshot from 2020-06-06 01-40-25](https://user-images.githubusercontent.com/29707062/83919318-f88b4b00-a797-11ea-83ac-12f7dcd79f0b.png)


 
For optimizing, I have reduced db queries by using the fact if a claim is a conflict to another claim then vice versa is also true. conflictKey is used for the same type of claims and for all these claims only 1 db count query is performed. if there are no conflicts, no badge is shown.